### PR TITLE
[#156923083] Add script to upload documents and terms of use markdown

### DIFF
--- a/documents/terms-of-use.md
+++ b/documents/terms-of-use.md
@@ -1,0 +1,197 @@
+GOV.UK Platform as a Service (PaaS)
+===================================
+
+Terms of Use
+------------
+
+These terms apply to your and your service's use of GOV.UK PaaS.
+
+Before you host a live service or private data on GOV.UK PaaS, your government organisation must have accepted and signed the GOV.UK PaaS data sharing and financial agreement (Memorandum of Understanding).
+
+Summary
+-------
+
+**If we accept your request to use GOV.UK PaaS, we agree to:**
+
+-   host your service's application or applications
+
+-   ensure that GOV.UK PaaS complies with the service standard
+
+-   ensure that GOV.UK PaaS has obtained suitable government security accreditation
+
+-   maintain the security of GOV.UK PaaS
+
+-   provide support for GOV.UK PaaS
+
+-   minimise downtime of GOV.UK PaaS
+
+-   alert you to any performance issue with GOV.UK PaaS
+
+-   pass on the cost of hosting your service and its applications, including any backing services, via a monthly invoice
+
+-   continuously iterate GOV.UK PaaS in line with user needs
+
+-   keep your data secure and comply with Data Protection Legislation/GDPR.
+
+**You agree to:**
+
+-   ensure that your service has passed the government security accreditation and the service standard assessment, where necessary
+
+-   only store data classified as 'official' and not store data classified as 'secret' or 'top secret'
+
+-   maintain the security of your apps
+
+-   not do anything which would, or is likely to, compromise the security or integrity of GOV.UK PaaS or its Sub-Contractors
+
+-   tell us before you load or security test your service/applications
+
+-   not load or security test GOV.UK PaaS or the underlying infrastructure
+
+-   ensure that your service/applications complies with the [12 factor development principles](https://12factor.net/)
+
+-   support your service/applications
+
+-   support the users of your service/applications
+
+-   let us know if you experience an issue with GOV.UK PaaS by using our ticketing system
+
+-   agree to pay the costs as passed onto you by GOV.UK PaaS team.
+
+**Before you can use GOV.UK PaaS for live services and private data you should have:**
+
+-   informed the GOV.UK PaaS product team that you intend to deploy a live service
+
+-   the relevant official level of security accreditation for your service/applications
+
+-   signed the Memorandum of Understanding agreement, if your organisation has not already done so
+
+-   signed this Terms of Use agreement.
+
+The agreement between GOV.UK PaaS and its users
+-----------------------------------------------
+
+We agree to:
+------------
+
+**Host your development service/applications**
+
+We will provide you with a trial account and host your service's development applications, providing all of the requirements summarised in these Terms of Use have been met.
+
+**Host your live service/applications**
+
+We will host your service's live applications, providing it complies with the service standard and all other requirements summarised in this document have been met.
+
+**Ensure that GOV.UK PaaS complies with the service standard**
+
+We will ensure that GOV.UK PaaS has passed the service assessment appropriate for its current level of development.
+
+**Ensure that GOV.UK PaaS has obtained its government security accreditation**
+
+We will ensure that GOV.UK PaaS has been through the information assurance process to assess information and security risks, to determine appropriate treatments for those risks and to obtain risk acceptance from the Cabinet Office Senior Information Risk Officer (SIRO) for data classified as 'official.' This work includes the completion of a Screening Data Protection Impact Assessment (SDPIA), or Full Data Protection Impact Assessment (DPIA) (if required) to ensure compliance with the applicable Data Protection legislation/GDPR. Further information can be found in the 'We agree to keep your data secure' section below.
+
+**Maintain the security of GOV.UK PaaS**
+
+We will inform you in a timely manner if GOV.UK PaaS experiences any security breaches.
+
+We will perform penetration testing on GOV.UK PaaS, so that you don't have to.
+
+We will ensure that all security or vulnerability updates and patches are applied in a timely manner, and where relevant, we will tell you when we deploy them.
+
+**Provide support for GOV.UK PaaS**
+
+GOV.UK PaaS provides 24/7 support. We provide a ticketing system and escalation routes for service teams to address incidents.
+
+Information on levels of support, response times, issue classification and escalation routes can be found [here](https://www.cloud.service.gov.uk/support-and-response-times).
+
+**Minimise down time of GOV.UK PaaS**
+
+We have an internal alerting system that will tell us when GOV.UK PaaS is experiencing technical issues that may result in the loss of the platform, and we will take remedial action immediately.
+
+**Alert you to any issue GOV.UK PaaS is experiencing**
+
+We will ensure that you are informed of any technical issues the platform experiences that may impact your service/applications. You can sign up to see the current status of GOV.UK PaaS and receive alerts [here](https://status.cloud.service.gov.uk/).
+
+**Invoice you monthly for using GOV.UK PaaS**
+
+GOV.UK PaaS team will invoice you monthly, in arrears, for the cost of hosting your service/applications on GOV.UK PaaS.
+
+**Continuously iterate GOV.UK PaaS in line with user needs**
+
+The GOV.UK PaaS team will continuously iterate the platform in line with tenants' needs throughout the lifetime of the product. GOV.UK PaaS will do this by ensuring that user research is an integral part of its development.
+
+**Keep your data secure**
+
+GOV.UK PaaS will store and process tenant admin user data in accordance with our [privacy policy](https://docs.cloud.service.gov.uk/#privacy-policy). A Data Processing Agreement is contained with the Memorandum of Understanding in which both parties obligations towards Data Protection are set out.
+
+GOV.UK PaaS will store and process tenant data in accordance with our Memorandum of Understanding and Terms of Use.
+
+You are responsible for the protection and security of the data used by your applications in compliance with applicable Data Protection Legislation/GDPR.
+
+GOV.UK PaaS has been through an information assurance process which includes the completion of a Screening Data Protection Impact Assessment (SDPIA) and Full Data Protection Impact Assessment to ensure compliance with the applicable Data Protection Legislation/GDPR.
+
+Cabinet Office/GDS act as Data Processor within the meaning of the Data Protection Legislation/GDPR, as parent organisation of GOV.UK PaaS. Your organisation remains the Data Controller within the meaning of the Data Protection Legislation/GDPR.
+
+If we receive Subject Access Requests which relate to data held by your team or product, we will pass tenants' details to the GDS channel that made the request to ensure compliance with Data Protection Legislation in order to meet both parties obligations.
+
+We maintain appropriate technical and organisational measures to protect data. We make sure our sub-contractors follow the same procedures.
+
+**Give you at least 30 days' notice if we change these terms**
+
+We'll email you if we need to change these terms. We'll tell you clearly what is changing and when the change will come into effect.
+
+Section 4.8 of the GOV.UK PaaS Memorandum of Understanding describes the document change management.
+
+You agree to:
+-------------
+
+**Ensure that your service complies with the service standard and has passed the government security accreditation.**
+
+You agree to ensure that your service has passed the appropriate service standard assessment, where necessary.
+
+You agree to assure your service through your organisation's information assurance (security) process, as required by your organisation. You don't need to include assurance of GOV.UK PaaS, since we've already done that - we can share the work we've done with you.
+
+**Maintain the security of your applications**
+
+You will secure access to your application and ensure that it has all relevant security and vulnerability updates and patches applied in a timely manner.
+
+You will collect and store any logs that you require in order to manage or investigate the operation of your app.
+
+**Not compromise the security or integrity of GOV.UK PaaS or any GOV.UK PaaS sub-contractor**
+
+You must tell us immediately if you experience any security breaches and comply with the notifications required under the Data Protection Legislation (para 1.8.3 under the Data Processing Agreement). This is so we can make sure other services running on GOV.UK PaaS, or our sub-contractors, are not affected and that both parties comply with obligations under the Data Protection Legislation/GDPR.
+
+You must follow industry best practices for keeping your API keys and other credentials secure.
+
+You must notify us at least 14 days before performing any load or security testing on your application hosted with GOV.UK PaaS.
+
+You must not conduct any load or security testing on GOV.UK PaaS itself, nor the underlying infrastructure, since we've already done that - we can share the work we've done with you.
+
+**Support the service/applications that are hosted on GOV.UK PaaS**
+
+You are responsible for providing technical support for your service/applications while it is hosted on GOV.UK PaaS. GOV.UK PaaS team will only provide technical support for the availability of the platform itself.
+
+**Provide user support for the users of your service/applications**
+
+You are responsible for continuing to provide user support (including assisted digital support) for the users of your service/applications.
+
+**Let us know if you experience an issue with GOV.UK PaaS via our ticketing system**
+
+If you experience an issue with GOV.UK PaaS, you will let us know via our ticketing system.
+
+You can find more information about how to contact us and how we will support you in the GOV.UK PaaS[ support plan](https://www.cloud.service.gov.uk/support-and-response-times).
+
+**Pay for the hosting resources your service/applications use, including for any backing services, which GOV.UK PaaS team will pass on to you**
+
+You will pay the invoice you receive from Government Digital Service charging you for the space you use to host your service/applications and additional backing services and additional platform costs. A full breakdown of what we charge for is in section 4.1 of the Memorandum of Understanding.
+
+You will pay this invoice in full within 30 days.
+
+Leaving GOV.UK PaaS
+===================
+
+Please let the GOV.UK PaaS team know if you want to remove your service/applications from the platform by emailing <gov-uk-paas-support@digital.cabinet-office.gov.uk>. We'll close your account and all of your data will be deleted.
+
+Suspending or Removing a Service
+================================
+
+GOV.UK PaaS may suspend or remove a service if it is in significant breach of these terms of use.

--- a/documents/upload-document-to-accounts.sh
+++ b/documents/upload-document-to-accounts.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -o pipefail -e -u
+
+SCRIPT_NAME="$0"
+
+usage() {
+  cat <<EOF
+Usage:
+
+  ${SCRIPT_NAME}  <prod|staging|dev_env> <document_id> <document_markdown.md>
+
+Examples:
+
+  ${SCRIPT_NAME}  prod terms-of-use terms-of-use.md
+
+Tip: You can generate the markdown using a service like https://euangoddard.github.io/clipboard2markdown/
+
+Remember to login in AWS before run this script
+
+EOF
+  exit 0
+}
+
+
+if [ "$#" -lt 3 ]; then
+  usage
+fi
+
+DEPLOY_ENV="$1"
+DOC_ID="$2"
+DOC_FILE="$3"
+
+case "${DEPLOY_ENV}" in
+  prod)
+    ACCOUNTS_URL="https://accounts.cloud.service.gov.uk"
+    ADMIN_URL="https://admin.cloud.service.gov.uk"
+  ;;
+  staging)
+    ACCOUNTS_URL="https://accounts.${DEPLOY_ENV}.cloudpipeline.digital"
+    ADMIN_URL="https://admin.${DEPLOY_ENV}.cloudpipeline.digital"
+  ;;
+  *)
+    ACCOUNTS_URL="https://accounts.${DEPLOY_ENV}.dev.cloudpipeline.digital"
+    ADMIN_URL="https://admin.${DEPLOY_ENV}.dev.cloudpipeline.digital"
+  ;;
+esac
+
+
+ACCOUNTS_PASSWORD="$(aws s3 cp s3://gds-paas-${DEPLOY_ENV}-state/cf-secrets.yml  - | awk '/secrets_paas_accounts_admin_password/ {print $2}')"
+
+curl \
+    -f \
+    -X PUT \
+    "${ACCOUNTS_URL}/documents/${DOC_ID}" \
+    -u admin:"${ACCOUNTS_PASSWORD}" \
+    -H "Content-Type: application/json" \
+    -d @<(jq -R -s '. as $file | { "content": $file }' "${DOC_FILE}")
+
+echo "Uploaded. Check it in ${ADMIN_URL}/agreements/${DOC_ID}"


### PR DESCRIPTION
What?
----

We will POST the documents for the contracts to the accounts service manually for
the time being.

But it still requires some steps, like create a valid json to do the POST,
track the markdown changes, do the actual POST.

Here we add a handy script to push the documents, and also add the terms
of use document into control version.

How to review?
-------------

Code review.

The script and the documents have already being used and in prod

Who?
----

Anyone but me