### PR TITLE
[#162013441] - Make PUTing documents idempotent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 paas-accounts
+/.idea


### PR DESCRIPTION
What
----

At the moment the PUT endpoint on the API creates a new version of the
document, even if it has the same content. This is confusing, because
the semantics of HTTP PUT are supposed to guarantee "idempotence" (that
is - "if you call this API with the same parameters multiple times the
effect will be the same as if you had called it once").

This commit adds a check so that if the name and the content of the
document are the same it won't be updated. This will allow us to PUT
documents from the pipeline without having to check that they don't
match the existing version.

How to review
-------------

* Code review
* Check the tests pass

Who can review?
---------------

Not @richardtowers