### PR TITLE
[#164728558] Bump the pinned go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 language: go
 
 go:
-  - 1.9
+  - 1.11
 
 services:
   - postgresql

--- a/manifest.yml
+++ b/manifest.yml
@@ -7,6 +7,6 @@ applications:
    instances: 2
    buildpack: go_buildpack
    env:
-     GOVERSION: go1.9
+     GOVERSION: go1.11
      GOPACKAGENAME: github.com/alphagov/paas-accounts
    command: ./bin/paas-accounts


### PR DESCRIPTION
What
------

Updating the pinned go version to 1.11 as 1.9 is no longer supported by the latest buildpack. 

How to review
------
Code review

Who can review
------

Not me
