### PR TITLE
[#166334735] Ensure email addresses can be null

### DIFF
--- a/api/api_suite_test.go
+++ b/api/api_suite_test.go
@@ -11,3 +11,8 @@ func TestApi(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Api Suite")
 }
+
+
+func strPoint(str string) *string {
+	return &str
+}

--- a/api/get_user_handler_test.go
+++ b/api/get_user_handler_test.go
@@ -31,7 +31,7 @@ var _ = Describe("GetUserHandler", func() {
 
 		user = database.User{
 			UUID:  "00000000-0000-0000-0000-000000000001",
-			Email: "example@example.com",
+			Email: strPoint("example@example.com"),
 		}
 		Expect(db.PostUser(user)).To(Succeed())
 	})

--- a/api/get_users_handler_test.go
+++ b/api/get_users_handler_test.go
@@ -34,17 +34,17 @@ var _ = Describe("GetUsersHandler", func() {
 
 		user1 = database.User{
 			UUID:  "00000000-0000-0000-0000-000000000001",
-			Email: "example1@example.com",
+			Email: strPoint("example1@example.com"),
 		}
 		Expect(db.PostUser(user1)).To(Succeed())
 		user2 = database.User{
 			UUID:  "00000000-0000-0000-0000-000000000002",
-			Email: "example2@example.com",
+			Email: strPoint("example2@example.com"),
 		}
 		Expect(db.PostUser(user2)).To(Succeed())
 		user3 = database.User{
 			UUID:  "00000000-0000-0000-0000-000000000003",
-			Email: "example3@example.com",
+			Email: strPoint("example3@example.com"),
 		}
 		Expect(db.PostUser(user3)).To(Succeed())
 

--- a/api/patch_user_handler_test.go
+++ b/api/patch_user_handler_test.go
@@ -31,7 +31,7 @@ var _ = Describe("PatchUserHandler", func() {
 
 		user := database.User{
 			UUID:  "00000000-0000-0000-0000-000000000001",
-			Email: "example@example.com",
+			Email: strPoint("example@example.com"),
 		}
 		Expect(db.PostUser(user)).To(Succeed())
 	})
@@ -44,7 +44,7 @@ var _ = Describe("PatchUserHandler", func() {
 	It("should update an existing user's email", func() {
 		userUUID := "00000000-0000-0000-0000-000000000001"
 		user := database.User{
-			Email: "newexample@example.com",
+			Email: strPoint("newexample@example.com"),
 		}
 
 		buf, err := json.Marshal(user)

--- a/api/post_agreements_handler.go
+++ b/api/post_agreements_handler.go
@@ -16,11 +16,15 @@ func PostAgreementsHandler(db *database.DB) echo.HandlerFunc {
 			return err
 		}
 
-		_, err = db.GetUser(c.Param("uuid"))
+		_, err = db.GetUser(agreement.UserUUID)
 		if err != nil {
-			db.PostUser(database.User{
+			err = db.PostUser(database.User{
 				UUID: agreement.UserUUID,
 			})
+
+			if err != nil {
+				return err
+			}
 		}
 
 		agreement.Date = time.Now()

--- a/api/post_user_handler.go
+++ b/api/post_user_handler.go
@@ -24,7 +24,7 @@ func PostUserHandler(db *database.DB) echo.HandlerFunc {
 			}
 
 			// No two users can have the same email
-			_, err = db.GetUserByEmail(user.Email)
+			_, err = db.GetUserByEmail(*user.Email)
 			if err == nil {
 				return c.NoContent(http.StatusBadRequest)
 			}

--- a/api/post_user_handler_test.go
+++ b/api/post_user_handler_test.go
@@ -38,7 +38,7 @@ var _ = Describe("PostUserHandler", func() {
 	It("should add a new user", func() {
 		user := database.User{
 			UUID:  "00000000-0000-0000-0000-000000000001",
-			Email: "example@example.com",
+			Email: strPoint("example@example.com"),
 		}
 
 		buf, err := json.Marshal(user)

--- a/database/db.go
+++ b/database/db.go
@@ -16,8 +16,8 @@ import (
 )
 
 type User struct {
-	UUID  string `json:"user_uuid" validate:"uuid"`
-	Email string `json:"user_email" validate:"required,email"`
+	UUID  string  `json:"user_uuid" validate:"uuid"`
+	Email *string `json:"user_email" validate:"required,email"`
 }
 
 type Document struct {
@@ -115,13 +115,13 @@ func (db *DB) GetDocument(name string) (Document, error) {
 func (db *DB) PostUser(user User) error {
 	_, err := db.GetUser(user.UUID)
 	if err == ErrUserNotFound {
-		_, err = db.conn.Exec(`INSERT INTO users (uuid, email) VALUES ($1, $2)`, user.UUID, strings.ToLower(user.Email))
+		_, err = db.conn.Exec(`INSERT INTO users (uuid, email) VALUES ($1, $2)`, user.UUID, lowerStrPoint(user.Email))
 	}
 	return err
 }
 
 func (db *DB) PatchUser(user User) error {
-	_, err := db.conn.Exec(`UPDATE users SET email= $2 WHERE uuid = $1`, user.UUID, strings.ToLower(user.Email))
+	_, err := db.conn.Exec(`UPDATE users SET email= $2 WHERE uuid = $1`, user.UUID, lowerStrPoint(user.Email))
 	return err
 }
 
@@ -292,4 +292,13 @@ func (db *DB) GetAgreementsForUserUUID(uuid string) ([]Agreement, error) {
 
 func (db *DB) Ping() error {
 	return db.conn.Ping()
+}
+
+func lowerStrPoint(str *string) *string {
+	if str == nil {
+		return nil
+	}
+
+	lower := strings.ToLower(*str)
+	return &lower
 }

--- a/database/db_suite_test.go
+++ b/database/db_suite_test.go
@@ -11,3 +11,7 @@ func TestDb(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Db Suite")
 }
+
+func strPoint(str string) *string{
+	return &str
+}

--- a/database/db_test.go
+++ b/database/db_test.go
@@ -129,7 +129,7 @@ var _ = Describe("DB", func() {
 		It("should post a user idempotently", func() {
 			user := User{
 				UUID:  "00000000-0000-0000-0000-000000000001",
-				Email: "example@example.com",
+				Email: strPoint("example@example.com"),
 			}
 
 			Expect(db.PostUser(user)).To(Succeed())
@@ -139,7 +139,7 @@ var _ = Describe("DB", func() {
 		It("should fail to post a user without a uuid", func() {
 			user := User{
 				UUID:  "",
-				Email: "example@example.com",
+				Email: strPoint("example@example.com"),
 			}
 
 			err := db.PostUser(user)
@@ -149,7 +149,7 @@ var _ = Describe("DB", func() {
 		It("should update user", func() {
 			user := User{
 				UUID:  "00000000-0000-0000-0000-000000000001",
-				Email: "newexample@example.com",
+				Email: strPoint("newexample@example.com"),
 			}
 
 			Expect(db.PatchUser(user)).To(Succeed())
@@ -158,13 +158,13 @@ var _ = Describe("DB", func() {
 		It("should return all users", func() {
 			user := User{
 				UUID:  "00000000-0000-0000-0000-000000000001",
-				Email: "example@example.com",
+				Email: strPoint("example@example.com"),
 			}
 			Expect(db.PostUser(user)).To(Succeed())
 
 			user1 := User{
 				UUID:  "00000000-0000-0000-0000-000000000002",
-				Email: "newexample@example.com",
+				Email: strPoint("newexample@example.com"),
 			}
 			Expect(db.PostUser(user1)).To(Succeed())
 
@@ -195,7 +195,7 @@ var _ = Describe("DB", func() {
 		BeforeEach(func() {
 			user = User{
 				UUID:  "00000000-0000-0000-0000-000000000001",
-				Email: "example@example.com",
+				Email: strPoint("example@example.com"),
 			}
 			document = Document{
 				Name:      "document",
@@ -276,7 +276,7 @@ var _ = Describe("DB", func() {
 		BeforeEach(func() {
 			user = User{
 				UUID:  "00000000-0000-0000-0000-000000000001",
-				Email: "example@example.com",
+				Email: strPoint("example@example.com"),
 			}
 			Expect(db.PostUser(user)).To(Succeed())
 


### PR DESCRIPTION
What
--
Previously, the database definition allowed the column to be nullable, but the
struct representing those rows in Go contained a string. This commit makes
that a string pointer, so that it can be sent to the database as null, instead of
the empty string.

How to review
--
1. Code review

Who can review
--
Paired on with @mogds 