### PR TITLE
Return 404 when a user doesn't exist

### DIFF
--- a/api/get_user_handler.go
+++ b/api/get_user_handler.go
@@ -11,6 +11,9 @@ func GetUserHandler(db *database.DB) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		user, err := db.GetUser(c.Param("uuid"))
 		if err != nil {
+			if err == database.ErrUserNotFound {
+				return c.NoContent(http.StatusNotFound)
+			}
 			return err
 		}
 

--- a/api/get_user_handler_test.go
+++ b/api/get_user_handler_test.go
@@ -70,8 +70,8 @@ var _ = Describe("GetUserHandler", func() {
 		ctx.SetParamValues("00000000-0000-0000-0000-000000000002")
 
 		handler := GetUserHandler(db)
-		Expect(handler(ctx)).ToNot(Succeed())
-		Expect(res.Code).To(Equal(http.StatusOK))
+		Expect(handler(ctx)).To(Succeed())
+		Expect(res.Code).To(Equal(http.StatusNotFound))
 	})
 
 	It("should return an error if the uuid is incorrect", func() {


### PR DESCRIPTION
What
----

Currently returns a 500 server error when a user doesn't exist. This updates the user handler to return a 404 if a user doesn't exist.

How to Review
----

Code review

Who can review
-----

Not me