### PR TITLE
[#166334937] Add username column to users table

### DIFF
--- a/api/get_user_documents_handler_test.go
+++ b/api/get_user_documents_handler_test.go
@@ -34,7 +34,9 @@ var _ = Describe("GetUserDocumentsHandler", func() {
 		Expect(db.Init()).To(Succeed())
 
 		user = database.User{
-			UUID: "00000000-0000-0000-0000-000000000001",
+			UUID:     "00000000-0000-0000-0000-000000000001",
+			Username: strPoint("example@example.com"),
+			Email:    strPoint("example@example.com"),
 		}
 		Expect(db.PostUser(user)).To(Succeed())
 

--- a/api/get_user_handler_test.go
+++ b/api/get_user_handler_test.go
@@ -30,8 +30,9 @@ var _ = Describe("GetUserHandler", func() {
 		Expect(db.Init()).To(Succeed())
 
 		user = database.User{
-			UUID:  "00000000-0000-0000-0000-000000000001",
-			Email: strPoint("example@example.com"),
+			UUID:     "00000000-0000-0000-0000-000000000001",
+			Email:    strPoint("example@example.com"),
+			Username: strPoint("example@example.com"),
 		}
 		Expect(db.PostUser(user)).To(Succeed())
 	})
@@ -54,7 +55,8 @@ var _ = Describe("GetUserHandler", func() {
 		Expect(handler(ctx)).To(Succeed())
 		Expect(res.Body).To(MatchJSON(`{
 				"user_uuid": "00000000-0000-0000-0000-000000000001",
-				"user_email": "example@example.com"
+				"user_email": "example@example.com",
+				"username": "example@example.com"
 			}`))
 		Expect(res.Code).To(Equal(http.StatusOK))
 		Expect(res.Header().Get("Content-Type")).To(Equal(echo.MIMEApplicationJSONCharsetUTF8))

--- a/api/get_users_handler.go
+++ b/api/get_users_handler.go
@@ -41,7 +41,7 @@ func GetUsersHandler(db *database.DB) echo.HandlerFunc {
 
 		email := params.Get("email")
 		if email != "" {
-			user, err := db.GetUserByEmail(email)
+			dbUsers, err := db.GetUserByEmail(email)
 			if err != nil {
 
 				if err == database.ErrUserNotFound {
@@ -50,7 +50,12 @@ func GetUsersHandler(db *database.DB) echo.HandlerFunc {
 
 				return err
 			}
-			users.Users = append(users.Users, &user)
+
+			if len(dbUsers) > 0 {
+				users.Users = dbUsers
+			} else {
+				users.Users = []*database.User{}
+			}
 			return c.JSON(http.StatusOK, users)
 		}
 

--- a/api/get_users_handler_test.go
+++ b/api/get_users_handler_test.go
@@ -33,18 +33,21 @@ var _ = Describe("GetUsersHandler", func() {
 		Expect(db.Init()).To(Succeed())
 
 		user1 = database.User{
-			UUID:  "00000000-0000-0000-0000-000000000001",
-			Email: strPoint("example1@example.com"),
+			UUID:     "00000000-0000-0000-0000-000000000001",
+			Email:    strPoint("example1@example.com"),
+			Username: strPoint("example1@example.com"),
 		}
 		Expect(db.PostUser(user1)).To(Succeed())
 		user2 = database.User{
-			UUID:  "00000000-0000-0000-0000-000000000002",
-			Email: strPoint("example2@example.com"),
+			UUID:     "00000000-0000-0000-0000-000000000002",
+			Email:    strPoint("example2@example.com"),
+			Username: strPoint("example2@example.com"),
 		}
 		Expect(db.PostUser(user2)).To(Succeed())
 		user3 = database.User{
-			UUID:  "00000000-0000-0000-0000-000000000003",
-			Email: strPoint("example3@example.com"),
+			UUID:     "00000000-0000-0000-0000-000000000003",
+			Email:    strPoint("example3@example.com"),
+			Username: strPoint("example3@example.com"),
 		}
 		Expect(db.PostUser(user3)).To(Succeed())
 
@@ -70,15 +73,18 @@ var _ = Describe("GetUsersHandler", func() {
 		Expect(res.Body).To(MatchJSON(`{
 			"users": [{
 				"user_uuid": "00000000-0000-0000-0000-000000000001",
-				"user_email": "example1@example.com"
+				"user_email": "example1@example.com",
+				"username": "example1@example.com"
 			},
 			{
 				"user_uuid": "00000000-0000-0000-0000-000000000002",
-				"user_email": "example2@example.com"
+				"user_email": "example2@example.com",
+				"username": "example2@example.com"
 			},
 			{
 				"user_uuid": "00000000-0000-0000-0000-000000000003",
-				"user_email": "example3@example.com"
+				"user_email": "example3@example.com",
+				"username": "example3@example.com"
 			}]
 		  }`))
 		Expect(res.Code).To(Equal(http.StatusOK))
@@ -99,7 +105,8 @@ var _ = Describe("GetUsersHandler", func() {
 		Expect(res.Body).To(MatchJSON(`{
 			"users": [{
 				"user_uuid": "00000000-0000-0000-0000-000000000003",
-				"user_email": "example3@example.com"
+				"user_email": "example3@example.com",
+				"username": "example3@example.com"
 			}]
 		  }`))
 		Expect(res.Code).To(Equal(http.StatusOK))

--- a/api/patch_user_handler.go
+++ b/api/patch_user_handler.go
@@ -1,31 +1,60 @@
 package api
 
 import (
+	"fmt"
+	"net/http"
+
+	"github.com/go-playground/validator"
+
 	"github.com/alphagov/paas-accounts/database"
 	"github.com/labstack/echo"
-	"net/http"
 )
 
+type PatchRequest struct {
+	Email    *string `json:"user_email" validate:"omitempty,email"`
+	Username string  `json:"username" validate:"required"`
+}
+
 func PatchUserHandler(db *database.DB) echo.HandlerFunc {
-		return func(c echo.Context) error {
-			var user database.User
-			err := c.Bind(&user)
-			if err != nil {
-				return err
-			}
+	return func(c echo.Context) error {
+		var payload PatchRequest
+		err := c.Bind(&payload)
+		if err != nil {
+			return err
+		}
 
-			user.UUID = c.Param("uuid")
+		err = c.Validate(payload)
+		if err != nil {
+			valerr := err.(validator.ValidationErrors)
+			s := fmt.Sprint(valerr)
+			return c.JSON(http.StatusBadRequest, s)
+		}
 
-			_, err = db.GetUser(c.Param("uuid"))
-			if err != nil {
+		user, err := db.GetUser(c.Param("uuid"))
+		if err != nil {
+			if err == database.ErrUserNotFound {
 				return c.JSON(http.StatusNotFound, err)
 			}
 
-			err = db.PatchUser(user)
-			if err != nil {
-				return err
-			}
+			return err
+		}
 
-			return c.JSON(http.StatusAccepted, user)
+		if user.Username == nil {
+			user.Username = &payload.Username
+		}
+
+		user.Email = payload.Email
+
+		err = db.PatchUser(user)
+		if err != nil {
+			return err
+		}
+
+		updateduser, err := db.GetUser(c.Param("uuid"))
+		if err != nil {
+			return err
+		}
+
+		return c.JSON(http.StatusAccepted, updateduser)
 	}
 }

--- a/api/patch_user_handler_test.go
+++ b/api/patch_user_handler_test.go
@@ -3,11 +3,12 @@ package api_test
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
 	"github.com/labstack/echo"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"net/http"
-	"net/http/httptest"
 
 	. "github.com/alphagov/paas-accounts/api"
 	"github.com/alphagov/paas-accounts/database"
@@ -30,10 +31,18 @@ var _ = Describe("PatchUserHandler", func() {
 		Expect(db.Init()).To(Succeed())
 
 		user := database.User{
-			UUID:  "00000000-0000-0000-0000-000000000001",
-			Email: strPoint("example@example.com"),
+			UUID:     "00000000-0000-0000-0000-000000000001",
+			Email:    strPoint("example@example.com"),
+			Username: strPoint("example@example.com"),
 		}
 		Expect(db.PostUser(user)).To(Succeed())
+
+		user2 := database.User{
+			UUID:     "00000000-0000-0000-0000-000000000002",
+			Email:    strPoint("example2@example.com"),
+			Username: nil,
+		}
+		Expect(db.PostUser(user2)).To(Succeed())
 	})
 
 	AfterEach(func() {
@@ -44,7 +53,8 @@ var _ = Describe("PatchUserHandler", func() {
 	It("should update an existing user's email", func() {
 		userUUID := "00000000-0000-0000-0000-000000000001"
 		user := database.User{
-			Email: strPoint("newexample@example.com"),
+			Email:    strPoint("newexample@example.com"),
+			Username: strPoint("newexample@example.com"),
 		}
 
 		buf, err := json.Marshal(user)
@@ -52,14 +62,22 @@ var _ = Describe("PatchUserHandler", func() {
 		req := httptest.NewRequest(echo.PATCH, "/", bytes.NewReader(buf))
 		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 		res := httptest.NewRecorder()
-		ctx := echo.New().NewContext(req, res)
+		server := NewServer(Config{
+			DB:                db,
+			BasicAuthUsername: "jeff",
+			BasicAuthPassword: "jefferson",
+			LogWriter:         GinkgoWriter,
+		})
+
+		ctx := server.AcquireContext()
+		ctx.Reset(req, res)
 		ctx.SetPath("/users/:uuid")
 		ctx.SetParamNames("uuid")
 		ctx.SetParamValues(userUUID)
 
 		handler := PatchUserHandler(db)
 		Expect(handler(ctx)).To(Succeed())
-		Expect(res.Body.String()).To(Equal(`{"user_uuid":"00000000-0000-0000-0000-000000000001","user_email":"newexample@example.com"}`))
+		Expect(res.Body.String()).To(Equal(`{"user_uuid":"00000000-0000-0000-0000-000000000001","user_email":"newexample@example.com","username":"example@example.com"}`))
 		Expect(res.Code).To(Equal(http.StatusAccepted))
 
 		user.UUID = userUUID
@@ -68,5 +86,83 @@ var _ = Describe("PatchUserHandler", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(userData.UUID).To(Equal(userUUID))
 		Expect(userData.Email).To(Equal(user.Email))
+	})
+
+	It("should update an existing user's username when the username is null", func() {
+		userUUID := "00000000-0000-0000-0000-000000000002"
+		user := database.User{
+			Email:    strPoint("example2@example.com"),
+			Username: strPoint("example2@example.com"),
+		}
+
+		buf, err := json.Marshal(user)
+		Expect(err).ToNot(HaveOccurred())
+		req := httptest.NewRequest(echo.PATCH, "/", bytes.NewReader(buf))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		res := httptest.NewRecorder()
+		server := NewServer(Config{
+			DB:                db,
+			BasicAuthUsername: "jeff",
+			BasicAuthPassword: "jefferson",
+			LogWriter:         GinkgoWriter,
+		})
+
+		ctx := server.AcquireContext()
+		ctx.Reset(req, res)
+		ctx.SetPath("/users/:uuid")
+		ctx.SetParamNames("uuid")
+		ctx.SetParamValues(userUUID)
+
+		handler := PatchUserHandler(db)
+		Expect(handler(ctx)).To(Succeed())
+		Expect(res.Body.String()).To(Equal(`{"user_uuid":"00000000-0000-0000-0000-000000000002","user_email":"example2@example.com","username":"example2@example.com"}`))
+		Expect(res.Code).To(Equal(http.StatusAccepted))
+
+		user.UUID = userUUID
+
+		userData, err := db.GetUser(user.UUID)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(userData.UUID).To(Equal(userUUID))
+		Expect(userData.Email).To(Equal(user.Email))
+		Expect(userData.Username).To(Equal(user.Username))
+	})
+
+	It("should not update an existing user's username when the username is not null", func() {
+		userUUID := "00000000-0000-0000-0000-000000000001"
+		user := database.User{
+			Email:    strPoint("example@example.com"),
+			Username: strPoint("donotupdate"),
+		}
+
+		buf, err := json.Marshal(user)
+		Expect(err).ToNot(HaveOccurred())
+		req := httptest.NewRequest(echo.PATCH, "/", bytes.NewReader(buf))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		res := httptest.NewRecorder()
+		server := NewServer(Config{
+			DB:                db,
+			BasicAuthUsername: "jeff",
+			BasicAuthPassword: "jefferson",
+			LogWriter:         GinkgoWriter,
+		})
+
+		ctx := server.AcquireContext()
+		ctx.Reset(req, res)
+		ctx.SetPath("/users/:uuid")
+		ctx.SetParamNames("uuid")
+		ctx.SetParamValues(userUUID)
+
+		handler := PatchUserHandler(db)
+		Expect(handler(ctx)).To(Succeed())
+		Expect(res.Body.String()).To(Equal(`{"user_uuid":"00000000-0000-0000-0000-000000000001","user_email":"example@example.com","username":"example@example.com"}`))
+		Expect(res.Code).To(Equal(http.StatusAccepted))
+
+		user.UUID = userUUID
+
+		userData, err := db.GetUser(user.UUID)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(userData.UUID).To(Equal(userUUID))
+		Expect(userData.Email).To(Equal(user.Email))
+		Expect(userData.Username).ToNot(Equal(user.Username))
 	})
 })

--- a/api/post_agreements_handler_test.go
+++ b/api/post_agreements_handler_test.go
@@ -46,7 +46,9 @@ var _ = Describe("PostAgreementsHandler", func() {
 		Expect(db.PutDocument(document)).To(Succeed())
 
 		user := database.User{
-			UUID: "00000000-0000-0000-0000-000000000001",
+			UUID:     "00000000-0000-0000-0000-000000000001",
+			Username: strPoint("example@example.com"),
+			Email:    strPoint("example@example.com"),
 		}
 		Expect(db.PostUser(user)).To(Succeed())
 
@@ -74,45 +76,5 @@ var _ = Describe("PostAgreementsHandler", func() {
 		Expect(agreements[0].UserUUID).To(Equal(input.UserUUID))
 		Expect(agreements[0].DocumentName).To(Equal(input.DocumentName))
 		Expect(agreements[0].Date).To(BeTemporally("~", time.Now(), time.Minute))
-	})
-
-	It("should accept an agreement even when user doesn't exist", func() {
-		document := database.Document{
-			Name:      "document-one",
-			Content:   "content one",
-			ValidFrom: time.Now(),
-		}
-		Expect(db.PutDocument(document)).To(Succeed())
-
-		userUUID := "00000000-0000-0000-0000-000000000001"
-
-		input := database.Agreement{
-			UserUUID:     userUUID,
-			DocumentName: document.Name,
-		}
-
-		buf, err := json.Marshal(input)
-		Expect(err).ToNot(HaveOccurred())
-		req := httptest.NewRequest(echo.PUT, "/", bytes.NewReader(buf))
-		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-		res := httptest.NewRecorder()
-		ctx := echo.New().NewContext(req, res)
-		ctx.SetPath("/agreements")
-
-		handler := PostAgreementsHandler(db)
-		Expect(handler(ctx)).To(Succeed())
-		Expect(res.Body.String()).To(BeEmpty())
-		Expect(res.Code).To(Equal(http.StatusCreated))
-
-		agreements, err := db.GetAgreementsForUserUUID(userUUID)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(agreements).To(HaveLen(1))
-		Expect(agreements[0].UserUUID).To(Equal(input.UserUUID))
-		Expect(agreements[0].DocumentName).To(Equal(input.DocumentName))
-		Expect(agreements[0].Date).To(BeTemporally("~", time.Now(), time.Minute))
-
-		user, err := db.GetUser(input.UserUUID)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(user.UUID).To(Equal(input.UserUUID))
 	})
 })

--- a/api/post_user_handler.go
+++ b/api/post_user_handler.go
@@ -23,16 +23,15 @@ func PostUserHandler(db *database.DB) echo.HandlerFunc {
 				return c.JSON(http.StatusBadRequest, s)
 			}
 
-			// No two users can have the same email
-			_, err = db.GetUserByEmail(*user.Email)
+			// No two users can have the same username
+			_, err = db.GetUserByUsername(*user.Username)
 			if err == nil {
 				return c.NoContent(http.StatusBadRequest)
 			}
 
 			_, err = db.GetUser(user.UUID)
 			if err == nil {
-				// Return a 201 so we're not leaking what does and doesn't exist
-				return c.NoContent(http.StatusCreated)
+				return c.NoContent(http.StatusConflict)
 			}
 
 			err = db.PostUser(user)
@@ -40,6 +39,11 @@ func PostUserHandler(db *database.DB) echo.HandlerFunc {
 				return err
 			}
 
-			return c.NoContent(http.StatusCreated)
+			createdUser, err := db.GetUser(user.UUID)
+			if err != nil {
+				return err
+			}
+
+			return c.JSON(http.StatusCreated, createdUser)
 	}
 }

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -139,7 +139,7 @@ var _ = Describe("Server", func() {
 		Entry("GET /users", "GET", "/users", 400),
 		Entry("GET /users/", "GET", "/users/", 400),
 		Entry("POST /users/", "POST", "/users/", 400),
-		Entry("PATCH /users/:uuid", "PATCH", "/users/569a91c6-7f5d-4dac-82a2-db85cc595c75", 404),
+		Entry("PATCH /users/:uuid", "PATCH", "/users/569a91c6-7f5d-4dac-82a2-db85cc595c75", 400),
 	)
 
 	Describe("ErrorHandler", func() {

--- a/database/sql/5_add_username.down.sql
+++ b/database/sql/5_add_username.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users ADD CONSTRAINT users_email_key UNIQUE(email);
+ALTER TABLE users DROP COLUMN username;

--- a/database/sql/5_add_username.up.sql
+++ b/database/sql/5_add_username.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users DROP CONSTRAINT users_email_key;
+ALTER TABLE users ADD COLUMN username text UNIQUE;


### PR DESCRIPTION
What
------

This adds a username column to the users table and updates the API surface/validation to match.

Not all users have an email address, such as the admin user, but we want to maintain a display name for all users. We add the username column for this purpose.

In the future, we will need to make the username field non-nullable, but only once other work to insert non-email-addressed users in to paas-accounts at different times.

How to review
-------

- Code Review
- cf push to your dev env and test http endpoints

Who can review
------

Not me or @AP-Hunt 
