### PR TITLE
[#166334937] Improve error handling in API

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,20 +72,42 @@ Get a user:
 
 Get users by guids (accepts multiple guids):
 
-    curl -u <USER>:<PASS> -G https://<HOSTNAME>/users?guids=00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000002
+    curl -u <USER>:<PASS> -G https://<HOSTNAME>/users?uuids=00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000002
 
 Get users by email (accepts a single email address):
 
-    curl -u <USER>:<PASS> -G https://<HOSTNAME>/users?email=example@example.com
+    curl -u <USER>:<PASS> -G https://<HOSTNAME>/users?email=example%40example.com
 
 ### POST /users/:uuid
 
 POST a user:
 
-    curl -u <USER>:<PASS> -H "Content-Type: application/json" -X POST -d '{"user_email": "example@example.com"' https://<HOSTNAME>/users/00000000-0000-0000-0000-000000000001
+    curl -u <USER>:<PASS> -H "Content-Type: application/json" -X POST -d '{"user_email": "example@example.com", "username": "example@example.com", "user_uuid": "00000000-0000-0000-0000-000000000001"}' https://<HOSTNAME>/users/00000000-0000-0000-0000-000000000001
 
 ### PATCH /users/:uuid
 
 PATCH a user:
 
-    curl -u <USER>:<PASS> -H "Content-Type: application/json" -X PUT -d '{"user_email": "newexample@example.com"}' https://<HOSTNAME>/users/00000000-0000-0000-0000-000000000001
+    curl -u <USER>:<PASS> -H "Content-Type: application/json" -X PATCH -d '{"user_email": "newexample@example.com"}' https://<HOSTNAME>/users/00000000-0000-0000-0000-000000000001
+
+### Error handling
+To handle an error in a handler function, such as an entity not being found or an internal server error, return one of the error types from `api/errors.go`
+
+```go
+func HttpHandler(db *database.DB) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		thing, err := db.GetAThing(c.Param("id"))
+		
+		if err != nil {
+			if err == database.ErrNotFound {
+				return NotFoundError{"thing not found"}
+			}
+			
+			return InternalServerError{err}
+		}
+		
+		return c.JSON(http.StatusOK, thing)
+	}
+	
+}
+```

--- a/api/errors.go
+++ b/api/errors.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"fmt"
+	"github.com/go-playground/validator"
+	"github.com/labstack/echo"
+	"net/http"
+)
+
+type NotFoundError struct {
+	Message string
+}
+
+func (err NotFoundError) Error() string {
+	return err.Message
+}
+
+
+type InternalServerError struct {
+	InternalError error
+}
+
+func (err InternalServerError) Error() string {
+	return "Something went wrong internally."
+}
+
+type ValidationError struct {
+	ValidationErrors validator.ValidationErrors
+}
+
+func (err ValidationError) Error() string {
+	return "A validation error occurred"
+}
+
+type messageErrorBody struct {
+	Message string `json:"Message"`
+}
+
+type validationErrorsBody struct {
+	ValidationErrors []fieldValidationError `json:"ValidationErrors"`
+}
+
+type fieldValidationError struct {
+	Field string `json:"Field"`
+	Error string `json:"Error"`
+}
+
+func ErrorHandler(err error, ctx echo.Context) {
+	switch err.(type) {
+	case *echo.HTTPError:
+		handleEchoHTTPError(err.(*echo.HTTPError), ctx)
+
+	case NotFoundError:
+		handleNotFound(err.(NotFoundError), ctx)
+
+	case InternalServerError:
+		handleInternalServerError(err.(InternalServerError), ctx)
+
+	case ValidationError:
+		handleValidationError(err.(ValidationError), ctx)
+
+	default:
+		handleGenericError(err, ctx)
+	}
+}
+
+
+
+func handleEchoHTTPError(err *echo.HTTPError, ctx echo.Context) {
+	code := err.Code
+	body := messageErrorBody{ Message: fmt.Sprintf("%v", err.Message) }
+
+	ctx.Logger().Error(err)
+	ctx.JSON(code, body)
+}
+
+func handleNotFound(err NotFoundError, ctx echo.Context) {
+	ctx.Logger().Error(err)
+	ctx.JSON(http.StatusNotFound, messageErrorBody{ Message: err.Error() })
+}
+
+func handleInternalServerError(err InternalServerError, ctx echo.Context) {
+	ctx.Logger().Error(err.InternalError)
+	ctx.NoContent(http.StatusInternalServerError)
+}
+
+func handleValidationError(err ValidationError, ctx echo.Context) {
+	body := validationErrorsBody{ ValidationErrors: []fieldValidationError{} }
+
+	for _, field := range err.ValidationErrors {
+		fieldErr := fieldValidationError{
+			Field: field.Field(),
+			Error: field.Tag(),
+		}
+
+		body.ValidationErrors = append(body.ValidationErrors, fieldErr)
+	}
+
+	ctx.Logger().Error(err)
+	ctx.JSON(http.StatusBadRequest, body)
+}
+
+func handleGenericError(err error, ctx echo.Context) {
+	ctx.Logger().Error(err)
+	ctx.JSON(http.StatusInternalServerError, messageErrorBody{ Message: err.Error() })
+}

--- a/api/errors.go
+++ b/api/errors.go
@@ -33,16 +33,16 @@ func (err ValidationError) Error() string {
 }
 
 type messageErrorBody struct {
-	Message string `json:"Message"`
+	Message string `json:"message"`
 }
 
 type validationErrorsBody struct {
-	ValidationErrors []fieldValidationError `json:"ValidationErrors"`
+	ValidationErrors []fieldValidationError `json:"validation-errors"`
 }
 
 type fieldValidationError struct {
-	Field string `json:"Field"`
-	Error string `json:"Error"`
+	Field string `json:"field"`
+	Error string `json:"error"`
 }
 
 func ErrorHandler(err error, ctx echo.Context) {

--- a/api/get_document_handler.go
+++ b/api/get_document_handler.go
@@ -7,7 +7,7 @@ import (
 	"github.com/labstack/echo"
 )
 
-var ErrDocumentNotFound = echo.NewHTTPError(http.StatusNotFound, "document not found")
+var ErrDocumentNotFound = NotFoundError{"document not found"}
 
 func GetDocumentHandler(db *database.DB) echo.HandlerFunc {
 	return func(c echo.Context) error {
@@ -15,7 +15,7 @@ func GetDocumentHandler(db *database.DB) echo.HandlerFunc {
 		if err == database.ErrDocumentNotFound {
 			return ErrDocumentNotFound
 		} else if err != nil {
-			return err
+			return InternalServerError{err}
 		}
 
 		return c.JSON(http.StatusOK, document)

--- a/api/get_document_handler_test.go
+++ b/api/get_document_handler_test.go
@@ -72,6 +72,6 @@ var _ = Describe("GetDocumentHandler", func() {
 		ctx.SetParamValues("one")
 
 		handler := GetDocumentHandler(db)
-		Expect(handler(ctx)).To(Equal(ErrDocumentNotFound))
+		Expect(handler(ctx)).To(BeAssignableToTypeOf(NotFoundError{}))
 	})
 })

--- a/api/get_user_documents_handler.go
+++ b/api/get_user_documents_handler.go
@@ -11,7 +11,7 @@ func GetUserDocumentsHandler(db *database.DB) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		allDocuments, err := db.GetDocumentsForUserUUID(c.Param("uuid"))
 		if err != nil {
-			return err
+			return InternalServerError{err}
 		}
 
 		onlyUnagreed := c.QueryParam("agreed") == "false"

--- a/api/get_user_handler.go
+++ b/api/get_user_handler.go
@@ -12,9 +12,9 @@ func GetUserHandler(db *database.DB) echo.HandlerFunc {
 		user, err := db.GetUser(c.Param("uuid"))
 		if err != nil {
 			if err == database.ErrUserNotFound {
-				return c.NoContent(http.StatusNotFound)
+				return NotFoundError{"user not found"}
 			}
-			return err
+			return InternalServerError{err}
 		}
 
 		return c.JSON(http.StatusOK, user)

--- a/api/get_user_handler_test.go
+++ b/api/get_user_handler_test.go
@@ -72,8 +72,7 @@ var _ = Describe("GetUserHandler", func() {
 		ctx.SetParamValues("00000000-0000-0000-0000-000000000002")
 
 		handler := GetUserHandler(db)
-		Expect(handler(ctx)).To(Succeed())
-		Expect(res.Code).To(Equal(http.StatusNotFound))
+		Expect(handler(ctx)).To(BeAssignableToTypeOf(NotFoundError{}))
 	})
 
 	It("should return an error if the uuid is incorrect", func() {
@@ -86,7 +85,6 @@ var _ = Describe("GetUserHandler", func() {
 		ctx.SetParamValues("00000000-0000-0000-0000")
 
 		handler := GetUserHandler(db)
-		Expect(handler(ctx)).ToNot(Succeed())
-		Expect(res.Code).To(Equal(http.StatusOK))
+		Expect(handler(ctx)).To(BeAssignableToTypeOf(InternalServerError{}))
 	})
 })

--- a/api/get_users_handler.go
+++ b/api/get_users_handler.go
@@ -33,7 +33,7 @@ func GetUsersHandler(db *database.DB) echo.HandlerFunc {
 			results, err := db.GetUsersByUUID(strings.Split(params["uuids"][0], ","))
 
 			if err != nil {
-				return c.NoContent(http.StatusInternalServerError)
+				return InternalServerError{err}
 			}
 			users.Users = results
 			return c.JSON(http.StatusOK, users)
@@ -45,10 +45,10 @@ func GetUsersHandler(db *database.DB) echo.HandlerFunc {
 			if err != nil {
 
 				if err == database.ErrUserNotFound {
-					return c.NoContent(http.StatusNotFound)
+					return NotFoundError{"user not found"}
 				}
 
-				return err
+				return InternalServerError{err}
 			}
 
 			if len(dbUsers) > 0 {

--- a/api/post_agreements_handler.go
+++ b/api/post_agreements_handler.go
@@ -13,7 +13,7 @@ func PostAgreementsHandler(db *database.DB) echo.HandlerFunc {
 		var agreement database.Agreement
 		err := c.Bind(&agreement)
 		if err != nil {
-			return err
+			return InternalServerError{err}
 		}
 
 		_, err = db.GetUser(agreement.UserUUID)
@@ -23,14 +23,14 @@ func PostAgreementsHandler(db *database.DB) echo.HandlerFunc {
 			})
 
 			if err != nil {
-				return err
+				return InternalServerError{err}
 			}
 		}
 
 		agreement.Date = time.Now()
 		err = db.PutAgreement(agreement)
 		if err != nil {
-			return err
+			return InternalServerError{err}
 		}
 
 		return c.NoContent(http.StatusCreated)

--- a/api/post_user_handler_test.go
+++ b/api/post_user_handler_test.go
@@ -105,8 +105,7 @@ var _ = Describe("PostUserHandler", func() {
 		ctx.SetParamValues("00000000-0000-0000-0000-000000000001")
 
 		handler := PostUserHandler(db)
-		Expect(handler(ctx)).To(Succeed())
-		Expect(res.Code).To(Equal(http.StatusBadRequest))
+		Expect(handler(ctx)).To(BeAssignableToTypeOf(ValidationError{}))
 	})
 
 	It("should return BadRequest if a user with the same username exists", func(){

--- a/api/put_document_handler.go
+++ b/api/put_document_handler.go
@@ -13,14 +13,14 @@ func PutDocumentHandler(db *database.DB) echo.HandlerFunc {
 		var document database.Document
 		err := c.Bind(&document)
 		if err != nil {
-			return err
+			return InternalServerError{err}
 		}
 
 		document.Name = c.Param("name")
 		document.ValidFrom = time.Now()
 		err = db.PutDocument(document)
 		if err != nil {
-			return err
+			return InternalServerError{err}
 		}
 
 		return c.NoContent(http.StatusCreated)

--- a/api/server.go
+++ b/api/server.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -57,22 +56,6 @@ func NewServer(config Config) *echo.Echo {
 	e.HTTPErrorHandler = ErrorHandler
 
 	return e
-}
-
-func ErrorHandler(err error, c echo.Context) {
-	code := http.StatusInternalServerError
-	msg := err.Error()
-	if he, ok := err.(*echo.HTTPError); ok {
-		code = he.Code
-		msg = fmt.Sprintf("%v", he.Message)
-	}
-	errJSON := struct {
-		Message string `json:"message"`
-	}{
-		Message: msg,
-	}
-	c.Logger().Error(err)
-	c.JSON(code, errJSON)
 }
 
 func status(c echo.Context) error {

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -144,16 +144,25 @@ var _ = Describe("Server", func() {
 	)
 
 	Describe("ErrorHandler", func() {
-		It("should return all errors as json", func() {
-			req := httptest.NewRequest(echo.GET, "/", nil)
-			res := httptest.NewRecorder()
+		var (
+			req *http.Request
+			res *httptest.ResponseRecorder
+			e   *echo.Echo
+			ctx echo.Context
+		)
 
-			e := echo.New()
+		BeforeEach(func() {
+			req = httptest.NewRequest(echo.GET, "/", nil)
+			res = httptest.NewRecorder()
+
+			e = echo.New()
 			e.Logger.SetOutput(GinkgoWriter)
 
-			ctx := e.NewContext(req, res)
+			ctx = e.NewContext(req, res)
 			ctx.SetPath("/")
+		})
 
+		It("should return all errors as json", func() {
 			err := errors.New("BANG")
 			ErrorHandler(err, ctx)
 			Expect(res.Body).To(MatchJSON(`{
@@ -164,60 +173,33 @@ var _ = Describe("Server", func() {
 		})
 
 		It("should return a NotFoundError as a 404", func() {
-			req := httptest.NewRequest(echo.GET, "/", nil)
-			res := httptest.NewRecorder()
-
-			e := echo.New()
-			e.Logger.SetOutput(GinkgoWriter)
-
-			ctx := e.NewContext(req, res)
-			ctx.SetPath("/")
-
 			err := NotFoundError{Message: "I was not found"}
 			ErrorHandler(err, ctx)
 			Expect(res.Body).To(MatchJSON(`{
-				"Message": "`+ err.Error() +`"
+				"Message": "` + err.Error() + `"
 			}`))
 			Expect(res.Code).To(Equal(http.StatusNotFound))
 			Expect(res.Header().Get("Content-Type")).To(Equal(echo.MIMEApplicationJSONCharsetUTF8))
 		})
 
 		It("should return an InternalServerError as a 500", func() {
-			req := httptest.NewRequest(echo.GET, "/", nil)
-			res := httptest.NewRecorder()
-
-			e := echo.New()
-			e.Logger.SetOutput(GinkgoWriter)
-
-			ctx := e.NewContext(req, res)
-			ctx.SetPath("/")
-
 			err := InternalServerError{InternalError: errors.New("internal error")}
 			ErrorHandler(err, ctx)
 			Expect(res.Code).To(Equal(http.StatusInternalServerError))
 		})
 
-		It("should return a ValidationError as a 400", func(){
-			req := httptest.NewRequest(echo.GET, "/", nil)
-			res := httptest.NewRecorder()
-
-			e := echo.New()
-			e.Logger.SetOutput(GinkgoWriter)
-
-			ctx := e.NewContext(req, res)
-			ctx.SetPath("/")
-
+		It("should return a ValidationError as a 400", func() {
 			type validatable struct {
 				Message string `validate:"required"`
 			}
 
-			instance := validatable{ Message: "" }
+			instance := validatable{Message: ""}
 			validatorInstance := validator.New()
 			errors := validatorInstance.Struct(instance)
 
 			Expect(errors).To(BeAssignableToTypeOf(validator.ValidationErrors{}))
 
-			err := ValidationError{ ValidationErrors: errors.(validator.ValidationErrors) }
+			err := ValidationError{ValidationErrors: errors.(validator.ValidationErrors)}
 			ErrorHandler(err, ctx)
 			Expect(res.Code).To(Equal(http.StatusBadRequest))
 			Expect(res.Body).To(MatchJSON(`{

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Server", func() {
 			b, err := ioutil.ReadAll(res.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(b)).To(MatchJSON(`{
-				"Message": "Unauthorized"
+				"message": "Unauthorized"
 			}`))
 		},
 		Entry("POST /agreements", "POST", "/agreements"),
@@ -166,7 +166,7 @@ var _ = Describe("Server", func() {
 			err := errors.New("BANG")
 			ErrorHandler(err, ctx)
 			Expect(res.Body).To(MatchJSON(`{
-				"Message": "` + err.Error() + `"
+				"message": "` + err.Error() + `"
 			}`))
 			Expect(res.Code).To(Equal(http.StatusInternalServerError))
 			Expect(res.Header().Get("Content-Type")).To(Equal(echo.MIMEApplicationJSONCharsetUTF8))
@@ -176,7 +176,7 @@ var _ = Describe("Server", func() {
 			err := NotFoundError{Message: "I was not found"}
 			ErrorHandler(err, ctx)
 			Expect(res.Body).To(MatchJSON(`{
-				"Message": "` + err.Error() + `"
+				"message": "` + err.Error() + `"
 			}`))
 			Expect(res.Code).To(Equal(http.StatusNotFound))
 			Expect(res.Header().Get("Content-Type")).To(Equal(echo.MIMEApplicationJSONCharsetUTF8))
@@ -203,10 +203,10 @@ var _ = Describe("Server", func() {
 			ErrorHandler(err, ctx)
 			Expect(res.Code).To(Equal(http.StatusBadRequest))
 			Expect(res.Body).To(MatchJSON(`{
-				"ValidationErrors": [
+				"validation-errors": [
 					{
-						"Field": "Message",
-						"Error": "required"
+						"field": "Message",
+						"error": "required"
 					}
 				]
 			}`))

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Server", func() {
 		Entry("PUT /documents/:name", "PUT", "/documents/doc-one"),
 		Entry("GET /documents/:name", "GET", "/documents/doc-one"),
 		Entry("GET /users/569a91c6-7f5d-4dac-82a2-db85cc595c75/documents", "GET", "/users/"),
-		Entry("GET /users?guids=569a91c6-7f5d-4dac-82a2-db85cc595c75", "GET", "/users"),
+		Entry("GET /users?uuids=569a91c6-7f5d-4dac-82a2-db85cc595c75", "GET", "/users"),
 		Entry("POST /users/", "POST", "/users/"),
 		Entry("PATCH /users/:uuid", "PATCH", "/users/569a91c6-7f5d-4dac-82a2-db85cc595c75"),
 	)


### PR DESCRIPTION
What
---
API error responses were inconsistent, and often returned just strings. This commit makes the errors consistent and always return JSON where appropriate.

It also provides error types for HTTP handler functions to return to indicate a class of error has occurred, and handles them in a server-wide error handler.

**🚨This branch is branched from add-username-to-users-166334937 and https://github.com/alphagov/paas-accounts/pull/10 needs merging first 🚨**

How to review
---
1. Code review

Who can review
---
Not @AP-Hunt 