### PR TITLE
[#179252161] bump golang to 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-accounts
 
-go 1.15
+go 1.16
 
 require (
 	github.com/Microsoft/go-winio v0.4.14 // indirect

--- a/manifest.yml
+++ b/manifest.yml
@@ -9,4 +9,4 @@ applications:
     command: ./bin/paas-accounts
 
     env:
-      GOVERSION: go1.15
+      GOVERSION: go1.16


### PR DESCRIPTION
## What

Bump the required version of golang in the module and cf manifest to 1.16, because we're about to roll out a buildpack which removes 1.15.

## How to review

Set a dev pipeline's `paas-accounts` resource's `branch` to this one?

## Who can review

Human engineers.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
