### PR TITLE
Bump golang to version 1.17

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Install Ginkgo CLI
       run: |
-        go get -u github.com/onsi/ginkgo/ginkgo
+        go install github.com/onsi/ginkgo/ginkgo@v1.4
 
     - name: Run tests
       env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,13 +4,13 @@ on:
 - pull_request
 
 env:
-  GO_VERSION: 1.13
+  GO_VERSION: 1.17
 
 jobs:
   unit:
     runs-on: ubuntu-latest
     name: Unit tests
-    
+
     services:
       postgres:
         image: postgres:12

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,20 @@
 module github.com/alphagov/paas-accounts
 
-go 1.16
+go 1.17
+
+require (
+	github.com/go-playground/validator v9.29.0+incompatible
+	github.com/golang-migrate/migrate v3.2.0+incompatible
+	github.com/labstack/echo v3.3.5+incompatible
+	github.com/lib/pq v1.10.4
+	github.com/onsi/ginkgo v1.4.0
+	github.com/onsi/gomega v1.3.0
+	github.com/satori/go.uuid v1.2.0
+)
 
 require (
 	github.com/Microsoft/go-winio v0.4.14 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v1.13.1 // indirect
@@ -11,24 +22,20 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/go-playground/locales v0.12.1 // indirect
 	github.com/go-playground/universal-translator v0.16.0 // indirect
-	github.com/go-playground/validator v9.29.0+incompatible
-	github.com/golang-migrate/migrate v3.2.0+incompatible
 	github.com/golang/protobuf v1.3.2 // indirect
-	github.com/labstack/echo v3.3.5+incompatible
 	github.com/labstack/gommon v0.2.2-0.20180426014445-588f4e8bddc6 // indirect
 	github.com/leodido/go-urn v1.1.0 // indirect
-	github.com/lib/pq v1.10.4
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.3 // indirect
-	github.com/onsi/ginkgo v1.4.0
-	github.com/onsi/gomega v1.3.0
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
-	github.com/satori/go.uuid v1.2.0
+	github.com/pkg/errors v0.8.1 // indirect
 	github.com/stretchr/testify v1.4.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 // indirect
 	golang.org/x/crypto v0.0.0-20180509205747-2d027ae1dddd // indirect
 	golang.org/x/net v0.0.0-20180509002218-f73e4c9ed3b7 // indirect
+	golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b // indirect
 	golang.org/x/text v0.3.0 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,5 @@
 github.com/Microsoft/go-winio v0.4.14 h1:+hMXMk01us9KgxGb7ftKQt2Xpf5hH/yky+TDA+qxleU=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -31,8 +30,6 @@ github.com/labstack/gommon v0.2.2-0.20180426014445-588f4e8bddc6 h1:OybVv/qNodrae
 github.com/labstack/gommon v0.2.2-0.20180426014445-588f4e8bddc6/go.mod h1:/tj9csK2iPSBvn+3NLM9e52usepMtrd5ilFYA+wQNJ4=
 github.com/leodido/go-urn v1.1.0 h1:Sm1gr51B1kKyfD2BlRcLSiEkffoG96g6TPv6eRoEiB8=
 github.com/leodido/go-urn v1.1.0/go.mod h1:+cyI34gQWZcE1eQU7NVgKkkzdXDQHr1dBMtdAPozLkw=
-github.com/lib/pq v0.0.0-20180327071824-d34b9ff171c2 h1:hRGSmZu7j271trc9sneMrpOW7GN5ngLm8YUZIPzf394=
-github.com/lib/pq v0.0.0-20180327071824-d34b9ff171c2/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.10.4 h1:SO9z7FRPzA03QhHKJrH5BXA6HU1rS4V2nIVrrNC1iYk=
 github.com/lib/pq v1.10.4/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRUIY4=

--- a/vendor/github.com/lib/pq/go.mod
+++ b/vendor/github.com/lib/pq/go.mod
@@ -1,3 +1,0 @@
-module github.com/lib/pq
-
-go 1.13

--- a/vendor/gopkg.in/yaml.v2/go.mod
+++ b/vendor/gopkg.in/yaml.v2/go.mod
@@ -1,5 +1,0 @@
-module "gopkg.in/yaml.v2"
-
-require (
-	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
-)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,6 @@
 # github.com/Microsoft/go-winio v0.4.14
+## explicit; go 1.12
+# github.com/davecgh/go-spew v1.1.1
 ## explicit
 # github.com/dgrijalva/jwt-go v3.2.0+incompatible
 ## explicit
@@ -44,7 +46,7 @@ github.com/labstack/gommon/random
 ## explicit
 github.com/leodido/go-urn
 # github.com/lib/pq v1.10.4
-## explicit
+## explicit; go 1.13
 github.com/lib/pq
 github.com/lib/pq/oid
 github.com/lib/pq/scram
@@ -91,6 +93,8 @@ github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
 # github.com/opencontainers/go-digest v1.0.0-rc1
 ## explicit
+# github.com/pkg/errors v0.8.1
+## explicit
 # github.com/satori/go.uuid v1.2.0
 ## explicit
 github.com/satori/go.uuid
@@ -112,6 +116,7 @@ golang.org/x/net/html
 golang.org/x/net/html/atom
 golang.org/x/net/html/charset
 # golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b
+## explicit; go 1.12
 golang.org/x/sys/unix
 # golang.org/x/text v0.3.0
 ## explicit
@@ -133,4 +138,5 @@ golang.org/x/text/transform
 # gopkg.in/go-playground/assert.v1 v1.2.1
 ## explicit
 # gopkg.in/yaml.v2 v2.2.2
+## explicit
 gopkg.in/yaml.v2


### PR DESCRIPTION
What
---

We need to upgrade to 1.17 before 1.18 in order to have overlap between
buildpacks.

Review
---
- Check tests are passing.