### PR TITLE
Update manifest to use golang 1.17

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -9,4 +9,4 @@ applications:
     command: ./bin/paas-accounts
 
     env:
-      GOVERSION: go1.16
+      GOVERSION: go1.17


### PR DESCRIPTION
Managed to overlook the manifest when trying to upgrade golang for the buildpack upgrade.