### PR TITLE
185509385 - Pin GitHub Actions to specific hashes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,9 +31,9 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
         with:
           go-version: "${{env.GO_VERSION}}"
 


### PR DESCRIPTION
Description:
- Currently we pin to versions which means that we automatically pull in the latest changes which presents a security risk as we don't know which code is running in our build pipeline.
- This PR fixes this by pinning to a specific hash
- A future PR will configure dependabot to raise PR's automatically for later versions of GitHub Actions against their hashes